### PR TITLE
Revert "Support laravel 5.7"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,15 +41,15 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/container": "~5.4.0|~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/contracts": "~5.4.0|~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/database": "~5.4.0|~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/events": "~5.4.0|~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0"
+        "illuminate/container": "~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/contracts": "~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/database": "~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/events": "~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0"
     },
     "require-dev": {
         "codedungeon/phpunit-result-printer": "^0.22.0",
-        "illuminate/config": "~5.4.0|~5.5.0|~5.6.0|~5.7.0",
+        "illuminate/config": "~5.4.0|~5.5.0|~5.6.0",
         "phpunit/phpunit": "^7.0.0"
     },
     "suggest": {


### PR DESCRIPTION
Reverts rinvex/laravel-repositories#183
Nothing should be merged into `master` directly, `develop` is the right branch to go [CONTRIBUTION TIPS](https://github.com/rinvex/laravel-repositories/blob/master/CONTRIBUTING.md)